### PR TITLE
Allow use of amzn-ship in non-default regions

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -7,8 +7,10 @@ module Deployer
   BASE_RELEASE = ENV['RELEASE_BUCKET']
   CMD = "/home/deploy/bin/deploy"
   KEYS = "./amzn.pem"
+  REGION = ENV['AWS_DEFAULT_REGION']
 
   def self.execute(app, env, ver)
+    AWS.config(region: REGION) if REGION
     ver = 'current' if ver.nil? || ver == ""
     g = asg.groups[key(app, env)]
     if g.exists?
@@ -34,10 +36,7 @@ module Deployer
 
   def self.asg
     @asg ||= begin
-      AWS::AutoScaling.new(
-        :access_key_id => ENV['AWS_ACCESS_KEY_ID'],
-        :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
-      )
+      AWS::AutoScaling.new
     end
   end
 

--- a/bin/release
+++ b/bin/release
@@ -9,8 +9,10 @@ module Releaser
   BASE_RELEASE = ENV['RELEASE_BUCKET']
   BASE_RELEASE_URL = URI(BASE_RELEASE)
   RELEASE_PREFIX = ENV['RELEASE_PREFIX']
+  REGION = ENV['AWS_DEFAULT_REGION']
 
   def self.execute(app, env, src_location)
+    AWS.config(region: REGION) if REGION
     create_bucket_if_needed
     ver = tag_source(src_location)
     archive = archive_source(app, env, ver, src_location)
@@ -82,10 +84,7 @@ module Releaser
 
   def self.s3
     @s3 ||= begin
-      AWS::S3.new(
-        :access_key_id => ENV['AWS_ACCESS_KEY_ID'],
-        :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
-      )
+      AWS::S3.new
     end
   end
 

--- a/bin/setup
+++ b/bin/setup
@@ -15,8 +15,10 @@ module Setup
   MIN = ENV['MIN_INSTANCES'].to_i
   MAX = ENV['MAX_INSTANCES'].to_i
   VOLUME_SIZE = ENV['VOLUME_SIZE'].to_i
+  REGION = ENV['AWS_DEFAULT_REGION']
 
   def self.execute(app, env)
+    AWS.config(region: REGION) if REGION
     create_sec_group
     create_key_pair
     create_role
@@ -180,37 +182,25 @@ module Setup
 
   def self.iam
     @iam ||= begin
-      AWS::IAM.new(
-        :access_key_id => ENV['AWS_ACCESS_KEY_ID'],
-        :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
-      )
+      AWS::IAM.new
     end
   end
 
   def self.ec2
     @ec2 ||= begin
-      AWS::EC2.new(
-        :access_key_id => ENV['AWS_ACCESS_KEY_ID'],
-        :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
-      )
+      AWS::EC2.new
     end
   end
 
   def self.asg
     @asg ||= begin
-      AWS::AutoScaling.new(
-        :access_key_id => ENV['AWS_ACCESS_KEY_ID'],
-        :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
-      )
+      AWS::AutoScaling.new
     end
   end
 
   def self.elb
     @elb ||= begin
-      AWS::ELB.new(
-        :access_key_id => ENV['AWS_ACCESS_KEY_ID'],
-        :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
-      )
+      AWS::ELB.new
     end
   end
 


### PR DESCRIPTION
The aws-sdk defaults to `us-east-1` if no region is specified. This is
great, unless you're elsewhere...

In addition, the SDK implicitly uses the standard AWS_ACCESS_KEY_ID and
AWS_SECRET_ACCESS_KEY so I've taken the liberty of removing them from
the .new calls.
