### PR TITLE
Use git-archive to create the release archive

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -76,7 +76,7 @@ module Releaser
   def self.archive_source(app, env, ver, location)
     tar_name = [app, env].join('-') + '.tar.gz'
     output_location = "/tmp/#{tar_name}"
-    `cd #{location}; tar -cz . > #{output_location}`
+    `cd #{location}; git archive --format=tar.gz --output=#{output_location} #{latest_tag(location)}`
     output_location
   end
 


### PR DESCRIPTION
`tar -cz .` doesn't respect git ignores and will happily copy log files,
cache files, etc. This does introduce a dependency on git, but it's
opinionated software, right? :)
